### PR TITLE
Declaring character arrays as extern variables in ibm.h

### DIFF
--- a/include/ibm.h
+++ b/include/ibm.h
@@ -1,5 +1,6 @@
 #ifndef QDMIBACKENDIBM_H
 #define QDMIBACKENDIBM_H
+
 #include "private/qdmi_internal.h"
 
 #include <dlfcn.h>
@@ -13,15 +14,9 @@ extern json_t *ibm_root;
 extern json_t *ibm_properties;
 extern char **gate_set;
 
-const char *backend_properties[] = 
-{
-    "backend_name", "backend_version",
-    "n_qubits", "basis_gates", "gates", "coupling_map"
-};
+extern char *backend_properties[];
 
-const char * qubit_properties[] =
-{
-    "T1", "T2", "readout_error", "readout_length"
-};
+extern char * qubit_properties[];
+
 int fetch_configuration();
 #endif // QDMIBACKENDIBM_H

--- a/src/ibm.c
+++ b/src/ibm.c
@@ -11,6 +11,17 @@ json_t *ibm_root;
 char **gate_set;
 json_t *ibm_properties;
 
+char *backend_properties[] = 
+{
+    "backend_name", "backend_version",
+    "n_qubits", "basis_gates", "gates", "coupling_map"
+};
+
+char * qubit_properties[] =
+{
+    "T1", "T2", "readout_error", "readout_length"
+};
+
 
 int QDMI_control_submit(QDMI_Device dev, QDMI_Fragment *frag, int numshots, QInfo info, QDMI_Job *job)
 {


### PR DESCRIPTION
Defining these variables in the header file leads to linker issues when linking the library with other libraries/executables. Linker complains about multiple definitions for these variables.